### PR TITLE
define_domain fixes and mpp_get/set

### DIFF
--- a/cfms/Makefile.am
+++ b/cfms/Makefile.am
@@ -37,9 +37,9 @@ cfms_mod@cmpp_smod.smod: cmpp.F90 cfms_mod.mod cfms_mod.smod
 cfms_mod.mod, cfms_mod.smod: cfms.F90 
 
 # Mod files are built and then installed as headers.
-MODFILES = cfms_mod.mod cfms_mod.smod cfms_mod@cmpp_smod.smod cfms_mod@cmpp_domains_smod.smod
+MODFILES = cfms_mod.mod #cfms_mod.smod cfms_mod@cmpp_smod.smod cfms_mod@cmpp_domains_smod.smod
 BUILT_SOURCES = $(MODFILES)
-nodist_include_HEADERS =  $(FMS_INC_FILES) #$(MODFILES)
+nodist_include_HEADERS =  $(FMS_INC_FILES) $(MODFILES)
 
 include_HEADERS = cfms.h cmpp.h cmpp_domains.h
 

--- a/cfms/cfms.F90
+++ b/cfms/cfms.F90
@@ -158,6 +158,46 @@ module cFMS_mod
        logical :: cFMS_domain_is_initialized
      end function
 
+     module subroutine cFMS_get_compute_domain(domain_id, xbegin, xend, ybegin, yend, xsize, xmax_size, ysize, ymax_size, &
+          x_is_global, y_is_global, tile_count, position, whalo, shalo) bind(C, name="cFMS_get_compute_domain")       
+       implicit none
+       integer, intent(in),  optional :: domain_id
+       integer, intent(out), optional :: xbegin, xend, ybegin, yend
+       integer, intent(out), optional :: xsize, xmax_size, ysize, ymax_size
+       logical, intent(out), optional :: x_is_global, y_is_global
+       integer, intent(in),  optional :: tile_count, position
+       integer, intent(in),  optional :: whalo, shalo
+     end subroutine
+
+     module subroutine cFMS_get_data_domain(domain_id, xbegin, xend, ybegin, yend, xsize, xmax_size, ysize, ymax_size, &
+          x_is_global, y_is_global, tile_count, position, whalo, shalo) bind(C, name="cFMS_get_data_domain")
+       implicit none
+       integer, intent(in), optional  :: domain_id
+       integer, intent(out), optional :: xbegin, xend, ybegin, yend
+       integer, intent(out), optional :: xsize, xmax_size, ysize, ymax_size
+       logical, intent(out), optional :: x_is_global, y_is_global
+       integer, intent(in), optional  :: tile_count, position
+       integer, intent(in), optional  :: whalo, shalo
+     end subroutine     
+
+     module subroutine cFMS_get_domain_name(domain_name_c, domain_id) bind(C, name="cFMS_get_domain_name")       
+       implicit none
+       character(c_char), intent(out) :: domain_name_c(NAME_LENGTH)
+       integer, intent(in),  optional :: domain_id
+     end subroutine
+
+     module subroutine cFMS_get_domain_pelist(pelist, domain_id) bind(C, name="cFMS_get_domain_pelist")         
+       implicit none
+       integer, intent(out) :: pelist(npes)
+       integer, intent(in),  optional :: domain_id
+     end subroutine 
+
+     module subroutine cFMS_get_layout(layout, domain_id) bind(C, name="cFMS_get_layout")
+       implicit none
+       integer, intent(out) :: layout(2)
+       integer, intent(in),  optional :: domain_id
+     end subroutine
+     
      module subroutine cFMS_set_compute_domain(domain_id, xbegin, xend, ybegin, yend, xsize, ysize, &
             x_is_global, y_is_global, tile_count) bind(C, name="cFMS_set_compute_domain")
        implicit none
@@ -205,6 +245,13 @@ module cFMS_mod
   public :: cFMS_define_layout
   public :: cFMS_define_nest_domains
   public :: cFMS_domain_is_initialized  
+  public :: cFMS_get_compute_domain
+  public :: cFMS_get_data_domain
+  public :: cFMS_get_domain_name
+  public :: cFMS_get_layout
+  public :: cFMS_set_compute_domain
+  public :: cFMS_set_data_domain
+  public :: cFMS_set_global_domain
 
 contains
 

--- a/cfms/cfms.F90
+++ b/cfms/cfms.F90
@@ -22,7 +22,6 @@ module cFMS_mod
   use FMS, only : FmsMppDomain2D, FmsMppDomainsNestDomain_type
   use FMS, only : fms_init, fms_end, fms_mpp_domains_init
   use FMS, only : fms_string_utils_c2f_string, fms_string_utils_f2c_string, fms_string_utils_cstring2cpointer
-  use platform_mod, only : FMS_PATH_LEN
   
   use FMS, only : fms_mpp_declare_pelist, fms_mpp_error, fms_mpp_get_current_pelist
   use FMS, only : fms_mpp_npes, fms_mpp_pe, fms_mpp_set_current_pelist
@@ -33,6 +32,12 @@ module cFMS_mod
   use FMS, only : fms_mpp_domains_get_layout, fms_mpp_domains_get_pelist
   use FMS, only : fms_mpp_domains_set_compute_domain, fms_mpp_domains_set_data_domain, fms_mpp_domains_set_global_domain
   use FMS, only : fms_mpp_domains_update_domains
+
+  use FMS, only : GLOBAL_DATA_DOMAIN, BGRID_NE, CGRID_NE, DGRID_NE, AGRID
+  use FMS, only : FOLD_SOUTH_EDGE, FOLD_NORTH_EDGE, FOLD_WEST_EDGE, FOLD_EAST_EDGE
+  use FMS, only : MPP_DOMAIN_TIME, CYCLIC_GLOBAL_DOMAIN, NUPDATE,EUPDATE, XUPDATE, YUPDATE
+  use FMS, only : NORTH, NORTH_EAST, EAST, SOUTH_EAST, CORNER, CENTER
+  use FMS, only : SOUTH, SOUTH_WEST, WEST, NORTH_WEST
   
   use iso_c_binding
 
@@ -56,12 +61,16 @@ module cFMS_mod
   
   integer, parameter :: NAME_LENGTH = 64 !< value taken from mpp_domains
   integer, parameter :: MESSAGE_LENGTH=128
-  character(FMS_PATH_LEN), parameter :: input_nml_path="./input.nml"
+  character(NAME_LENGTH), parameter :: input_nml_path="./input.nml"
 
-  integer, public, bind(c, name="cFMS_pelist_npes") :: npes
-  integer, public, bind(c, name="NOTE")      :: NOTE_C    = NOTE
-  integer, public, bind(c, name="WARNING")   :: WARNING_C = WARNING
-  integer, public, bind(c, name="FATAL")     :: FATAL_C    = FATAL
+  integer, public, bind(C, name="cFMS_pelist_npes") :: npes
+  integer, public, bind(C, name="NOTE")    :: NOTE_C    = NOTE
+  integer, public, bind(C, name="WARNING") :: WARNING_C = WARNING
+  integer, public, bind(C, name="FATAL")   :: FATAL_C    = FATAL
+  integer, public, bind(C, name="WEST")  :: WEST_C = WEST
+  integer, public, bind(C, name="EAST")  :: EAST_C = EAST
+  integer, public, bind(C, name="SOUTH") :: SOUTH_C = SOUTH
+  integer, public, bind(C, name="NORTH") :: NORTH_C = NORTH
   
   type(FmsMppDomain2D), allocatable, target,  public :: domain(:)
   type(FmsMppDomain2D), pointer  :: current_domain  
@@ -120,7 +129,7 @@ module cFMS_mod
        integer, intent(in), optional :: xflags, yflags
        integer, intent(in), optional :: xhalo, yhalo
        integer, intent(in), optional :: xextent(layout(1)), yextent(layout(2))
-       logical(c_bool), intent(in), optional :: maskmap(layout(1),layout(2))
+       type(c_ptr), intent(in), optional :: maskmap
        character(c_char), intent(in), optional :: name(NAME_LENGTH)
        logical(c_bool), intent(in), optional :: symmetry
        integer, intent(in), optional :: memory_size(2)

--- a/cfms/cfms.F90
+++ b/cfms/cfms.F90
@@ -158,6 +158,15 @@ module cFMS_mod
        logical :: cFMS_domain_is_initialized
      end function
 
+     module subroutine cFMS_set_compute_domain(domain_id, xbegin, xend, ybegin, yend, xsize, ysize, &
+            x_is_global, y_is_global, tile_count) bind(C, name="cFMS_set_compute_domain")
+       implicit none
+       integer, intent(in),  optional :: domain_id
+       integer, intent(in),  optional :: xbegin, xend, ybegin, yend, xsize, ysize
+       logical, intent(in),  optional :: x_is_global, y_is_global
+       integer, intent(in),  optional :: tile_count
+     end subroutine
+     
      module subroutine cFMS_set_current_domain(domain_id) bind(C, name="cFMS_set_current_domain")
        implicit none
        integer, intent(in), optional :: domain_id
@@ -167,6 +176,25 @@ module cFMS_mod
        implicit none
        integer, intent(in), optional :: nest_domain_id
      end subroutine
+
+     module subroutine cFMS_set_data_domain(domain_id, xbegin, xend, ybegin, yend, xsize, ysize, &
+          x_is_global, y_is_global, tile_count) bind(C, name="cFMS_set_data_domain")
+       
+       implicit none
+       integer, intent(in),  optional :: domain_id
+       integer, intent(in),  optional :: xbegin, xend, ybegin, yend, xsize, ysize
+       logical, intent(in),  optional :: x_is_global, y_is_global
+       integer, intent(in),  optional :: tile_count
+     end subroutine
+
+     module subroutine cFMS_set_global_domain(domain_id, xbegin, xend, ybegin, yend, xsize, ysize, tile_count) &
+          bind(C, name="cFMS_set_global_domain")
+       implicit none
+       integer, intent(in),  optional :: domain_id
+       integer, intent(in),  optional :: xbegin, xend, ybegin, yend, xsize, ysize
+       integer, intent(in),  optional :: tile_count
+     end subroutine     
+
      
   end interface
   

--- a/cfms/cfms.F90
+++ b/cfms/cfms.F90
@@ -105,7 +105,7 @@ module cFMS_mod
      module subroutine cFMS_set_current_pelist(pelist, no_sync) bind(C, name="cFMS_set_current_pelist")
        implicit none
        integer, intent(in), optional :: pelist(npes)
-       logical, intent(in), optional :: no_sync
+       logical(c_bool), intent(in), optional :: no_sync
      end subroutine
 
      module subroutine cFMS_define_domains(global_indices, layout, domain_id, pelist,     &
@@ -120,15 +120,15 @@ module cFMS_mod
        integer, intent(in), optional :: xflags, yflags
        integer, intent(in), optional :: xhalo, yhalo
        integer, intent(in), optional :: xextent(layout(1)), yextent(layout(2))
-       logical, intent(in), optional :: maskmap(layout(1),layout(2))
+       logical(c_bool), intent(in), optional :: maskmap(layout(1),layout(2))
        character(c_char), intent(in), optional :: name(NAME_LENGTH)
-       logical, intent(in), optional :: symmetry
+       logical(c_bool), intent(in), optional :: symmetry
        integer, intent(in), optional :: memory_size(2)
        integer, intent(in), optional :: whalo, ehalo, shalo, nhalo
-       logical, intent(in), optional :: is_mosaic
+       logical(c_bool), intent(in), optional :: is_mosaic
        integer, intent(inout),  optional :: tile_count
        integer, intent(inout),  optional :: tile_id
-       logical, intent(in), optional :: complete
+       logical(c_bool), intent(in), optional :: complete
        integer, intent(in), optional :: x_cyclic_offset
        integer, intent(in), optional :: y_cyclic_offset
      end subroutine
@@ -170,7 +170,7 @@ module cFMS_mod
      module function cFMS_domain_is_initialized(domain_id) bind(C, name="cFMS_domain_is_initialized")
        implicit none
        integer, intent(in), optional :: domain_id
-       logical :: cFMS_domain_is_initialized
+       logical(c_bool) :: cFMS_domain_is_initialized
      end function
 
      module subroutine cFMS_get_compute_domain(domain_id, xbegin, xend, ybegin, yend, xsize, xmax_size, ysize, ymax_size, &
@@ -179,7 +179,7 @@ module cFMS_mod
        integer, intent(in),  optional :: domain_id
        integer, intent(out), optional :: xbegin, xend, ybegin, yend
        integer, intent(out), optional :: xsize, xmax_size, ysize, ymax_size
-       logical, intent(out), optional :: x_is_global, y_is_global
+       logical(c_bool), intent(out), optional :: x_is_global, y_is_global
        integer, intent(inout), optional :: tile_count
        integer, intent(in),  optional :: position
        integer, intent(in),  optional :: whalo, shalo
@@ -191,7 +191,7 @@ module cFMS_mod
        integer, intent(in),  optional :: domain_id
        integer, intent(out), optional :: xbegin, xend, ybegin, yend
        integer, intent(out), optional :: xsize, xmax_size, ysize, ymax_size
-       logical, intent(out), optional :: x_is_global, y_is_global
+       logical(c_bool), intent(out), optional :: x_is_global, y_is_global
        integer, intent(inout), optional :: tile_count
        integer, intent(in), optional  :: position
        integer, intent(in), optional  :: whalo, shalo
@@ -220,7 +220,7 @@ module cFMS_mod
        implicit none
        integer, intent(in),    optional :: domain_id
        integer, intent(inout), optional :: xbegin, xend, ybegin, yend, xsize, ysize
-       logical, intent(inout), optional :: x_is_global, y_is_global
+       logical(c_bool), intent(inout), optional :: x_is_global, y_is_global
        integer, intent(inout), optional :: tile_count
        integer, intent(in),    optional :: whalo, shalo
      end subroutine
@@ -241,7 +241,7 @@ module cFMS_mod
        implicit none
        integer, intent(in),    optional :: domain_id
        integer, intent(inout), optional :: xbegin, xend, ybegin, yend, xsize, ysize
-       logical, intent(in),    optional :: x_is_global, y_is_global
+       logical(c_bool), intent(in), optional :: x_is_global, y_is_global
        integer, intent(inout), optional :: tile_count
        integer, intent(in),    optional :: whalo, shalo
      end subroutine

--- a/cfms/cfms.F90
+++ b/cfms/cfms.F90
@@ -37,8 +37,23 @@ module cFMS_mod
   use iso_c_binding
 
   implicit none
-  private
 
+  public :: cFMS_init
+  public :: cFMS_end, cFMS_error, cFMS_set_pelist_npes
+  public :: cFMS_declare_pelist, cFMS_get_current_pelist, cFMS_npes, cFMS_pe, cFMS_set_current_pelist
+  public :: cFMS_define_domains
+  public :: cFMS_define_io_domain
+  public :: cFMS_define_layout
+  public :: cFMS_define_nest_domains
+  public :: cFMS_domain_is_initialized  
+  public :: cFMS_get_compute_domain
+  public :: cFMS_get_data_domain
+  public :: cFMS_get_domain_name
+  public :: cFMS_get_layout
+  public :: cFMS_set_compute_domain
+  public :: cFMS_set_data_domain
+  public :: cFMS_set_global_domain
+  
   integer, parameter :: NAME_LENGTH = 64 !< value taken from mpp_domains
   integer, parameter :: MESSAGE_LENGTH=128
   character(FMS_PATH_LEN), parameter :: input_nml_path="./input.nml"
@@ -53,7 +68,7 @@ module cFMS_mod
 
   type(FmsMppDomainsNestDomain_type), allocatable, target, public :: nest_domain(:)
   type(FmsMppDomainsNestDomain_type), pointer :: current_nest_domain
-  
+
   interface
 
      module subroutine cFMS_declare_pelist(pelist, name, commID) bind(C, name="cFMS_declare_pelist")
@@ -98,24 +113,24 @@ module cFMS_mod
           symmetry, memory_size, whalo, ehalo, shalo, nhalo, is_mosaic, tile_count,       &
           tile_id, complete, x_cyclic_offset, y_cyclic_offset) bind(C, name="cFMS_define_domains")
        implicit none   
-       integer, intent(in) :: global_indices(4) 
+       integer, intent(inout) :: global_indices(4) 
        integer, intent(in) :: layout(2)
-       integer, intent(in),  optional :: domain_id
+       integer, intent(in), optional :: domain_id
        integer, intent(in), optional :: pelist(npes) 
-       integer, intent(in),  optional :: xflags, yflags
-       integer, intent(in),  optional :: xhalo, yhalo
+       integer, intent(in), optional :: xflags, yflags
+       integer, intent(in), optional :: xhalo, yhalo
        integer, intent(in), optional :: xextent(layout(1)), yextent(layout(2))
        logical, intent(in), optional :: maskmap(layout(1),layout(2))
        character(c_char), intent(in), optional :: name(NAME_LENGTH)
-       logical, intent(in),  optional :: symmetry
+       logical, intent(in), optional :: symmetry
        integer, intent(in), optional :: memory_size(2)
-       integer, intent(in),  optional :: whalo, ehalo, shalo, nhalo
-       logical, intent(in),  optional :: is_mosaic
-       integer, intent(in),  optional :: tile_count
-       integer, intent(in),  optional :: tile_id
-       logical, intent(in),  optional :: complete
-       integer, intent(in),  optional :: x_cyclic_offset
-       integer, intent(in),  optional :: y_cyclic_offset
+       integer, intent(in), optional :: whalo, ehalo, shalo, nhalo
+       logical, intent(in), optional :: is_mosaic
+       integer, intent(inout),  optional :: tile_count
+       integer, intent(inout),  optional :: tile_id
+       logical, intent(in), optional :: complete
+       integer, intent(in), optional :: x_cyclic_offset
+       integer, intent(in), optional :: y_cyclic_offset
      end subroutine
 
      module subroutine cFMS_define_io_domain(io_layout, domain_id) bind(C, name="cFMS_define_io_domain")
@@ -165,18 +180,20 @@ module cFMS_mod
        integer, intent(out), optional :: xbegin, xend, ybegin, yend
        integer, intent(out), optional :: xsize, xmax_size, ysize, ymax_size
        logical, intent(out), optional :: x_is_global, y_is_global
-       integer, intent(in),  optional :: tile_count, position
+       integer, intent(inout), optional :: tile_count
+       integer, intent(in),  optional :: position
        integer, intent(in),  optional :: whalo, shalo
      end subroutine
 
      module subroutine cFMS_get_data_domain(domain_id, xbegin, xend, ybegin, yend, xsize, xmax_size, ysize, ymax_size, &
           x_is_global, y_is_global, tile_count, position, whalo, shalo) bind(C, name="cFMS_get_data_domain")
        implicit none
-       integer, intent(in), optional  :: domain_id
+       integer, intent(in),  optional :: domain_id
        integer, intent(out), optional :: xbegin, xend, ybegin, yend
        integer, intent(out), optional :: xsize, xmax_size, ysize, ymax_size
        logical, intent(out), optional :: x_is_global, y_is_global
-       integer, intent(in), optional  :: tile_count, position
+       integer, intent(inout), optional :: tile_count
+       integer, intent(in), optional  :: position
        integer, intent(in), optional  :: whalo, shalo
      end subroutine     
 
@@ -199,12 +216,13 @@ module cFMS_mod
      end subroutine
      
      module subroutine cFMS_set_compute_domain(domain_id, xbegin, xend, ybegin, yend, xsize, ysize, &
-            x_is_global, y_is_global, tile_count) bind(C, name="cFMS_set_compute_domain")
+            x_is_global, y_is_global, tile_count, whalo, shalo) bind(C, name="cFMS_set_compute_domain")
        implicit none
-       integer, intent(in),  optional :: domain_id
-       integer, intent(in),  optional :: xbegin, xend, ybegin, yend, xsize, ysize
-       logical, intent(in),  optional :: x_is_global, y_is_global
-       integer, intent(in),  optional :: tile_count
+       integer, intent(in),    optional :: domain_id
+       integer, intent(inout), optional :: xbegin, xend, ybegin, yend, xsize, ysize
+       logical, intent(inout), optional :: x_is_global, y_is_global
+       integer, intent(inout), optional :: tile_count
+       integer, intent(in),    optional :: whalo, shalo
      end subroutine
      
      module subroutine cFMS_set_current_domain(domain_id) bind(C, name="cFMS_set_current_domain")
@@ -218,51 +236,37 @@ module cFMS_mod
      end subroutine
 
      module subroutine cFMS_set_data_domain(domain_id, xbegin, xend, ybegin, yend, xsize, ysize, &
-          x_is_global, y_is_global, tile_count) bind(C, name="cFMS_set_data_domain")
+          x_is_global, y_is_global, tile_count, whalo, shalo) bind(C, name="cFMS_set_data_domain")
        
        implicit none
-       integer, intent(in),  optional :: domain_id
-       integer, intent(in),  optional :: xbegin, xend, ybegin, yend, xsize, ysize
-       logical, intent(in),  optional :: x_is_global, y_is_global
-       integer, intent(in),  optional :: tile_count
+       integer, intent(in),    optional :: domain_id
+       integer, intent(inout), optional :: xbegin, xend, ybegin, yend, xsize, ysize
+       logical, intent(in),    optional :: x_is_global, y_is_global
+       integer, intent(inout), optional :: tile_count
+       integer, intent(in),    optional :: whalo, shalo
      end subroutine
 
-     module subroutine cFMS_set_global_domain(domain_id, xbegin, xend, ybegin, yend, xsize, ysize, tile_count) &
-          bind(C, name="cFMS_set_global_domain")
+     module subroutine cFMS_set_global_domain(domain_id, xbegin, xend, ybegin, yend, xsize, ysize, &
+                                              tile_count, whalo, shalo) bind(C, name="cFMS_set_global_domain")
        implicit none
-       integer, intent(in),  optional :: domain_id
-       integer, intent(in),  optional :: xbegin, xend, ybegin, yend, xsize, ysize
-       integer, intent(in),  optional :: tile_count
+       integer, intent(in),    optional :: domain_id
+       integer, intent(inout), optional :: xbegin, xend, ybegin, yend, xsize, ysize
+       integer, intent(inout), optional :: tile_count
+       integer, intent(in),    optional :: whalo, shalo
      end subroutine     
-
      
   end interface
-  
-  public :: cFMS_end, cFMS_error, cFMS_init, cFMS_set_pelist_npes
-  public :: cFMS_declare_pelist, cFMS_get_current_pelist, cFMS_npes, cFMS_pe, cFMS_set_current_pelist
-  public :: cFMS_define_domains
-  public :: cFMS_define_io_domain
-  public :: cFMS_define_layout
-  public :: cFMS_define_nest_domains
-  public :: cFMS_domain_is_initialized  
-  public :: cFMS_get_compute_domain
-  public :: cFMS_get_data_domain
-  public :: cFMS_get_domain_name
-  public :: cFMS_get_layout
-  public :: cFMS_set_compute_domain
-  public :: cFMS_set_data_domain
-  public :: cFMS_set_global_domain
 
 contains
 
   !> cFMS_end
-  module subroutine cFMS_end() bind(C, name="cFMS_end")
+  subroutine cFMS_end() bind(C, name="cFMS_end")
     implicit none
     call fms_end()
   end subroutine cFMS_end
 
-  !> cFMS_init
-  module subroutine cFMS_init(localcomm, alt_input_nml_path, ndomain, nnest_domain) bind(C, name="cFMS_init")
+  !> cfms_init
+  subroutine cFMS_init(localcomm, alt_input_nml_path, ndomain, nnest_domain) bind(C,  name="cFMS_init")
     
     implicit none
     integer, intent(in), optional :: localcomm
@@ -290,10 +294,10 @@ contains
        allocate(nest_domain(0:0))
     end if
     
-  end subroutine cFMS_init
+  end subroutine cfms_init
 
   !> cFMS_set_npes
-  module subroutine cFMS_set_pelist_npes(npes_in) bind(C, name="cFMS_set_pelist_npes")
+  subroutine cFMS_set_pelist_npes(npes_in) bind(C, name="cFMS_set_pelist_npes")
     implicit none
     integer, intent(in) :: npes_in
     npes = npes_in

--- a/cfms/cfms.h
+++ b/cfms/cfms.h
@@ -23,9 +23,16 @@
 #include <cmpp.h>
 #include <cmpp_domains.h>
 
+#define NAME_LENGTH 64 
+#define MESSAGE_LENGTH 128
+
 extern const int NOTE;
 extern const int WARNING;
 extern const int FATAL;
+extern const int WEST;
+extern const int EAST;
+extern const int SOUTH;
+extern const int NORTH;
 
 extern void cFMS_init(int *localcomm, char *alt_input_nml_path, int *ndomain, int *nnest_domain);
 

--- a/cfms/cmpp.F90
+++ b/cfms/cmpp.F90
@@ -44,7 +44,7 @@ contains
     implicit none
     integer, intent(in), value :: errortype
     character(c_char), intent(in), optional :: errormsg(MESSAGE_LENGTH)
-    character(len=MESSAGE_LENGTH) :: errormsg_f
+    character(len=MESSAGE_LENGTH) :: errormsg_f=""
 
     if(present(errormsg)) errormsg_f = fms_string_utils_c2f_string(errormsg)
     call fms_mpp_error(errortype, trim(errormsg_f))
@@ -86,9 +86,13 @@ contains
 
     implicit none
     integer, intent(in), optional :: pelist(npes)
-    logical, intent(in), optional :: no_sync
+    logical(c_bool), intent(in), optional :: no_sync
 
-    call fms_mpp_set_current_pelist(pelist, no_sync)
+    if(present(no_sync)) then
+       call fms_mpp_set_current_pelist(pelist, logical(no_sync))
+    else
+       call fms_mpp_set_current_pelist(pelist)
+    end if
     
   end subroutine cFMS_set_current_pelist
   

--- a/cfms/cmpp_domains.F90
+++ b/cfms/cmpp_domains.F90
@@ -146,6 +146,32 @@ contains
 
   end function cFMS_domain_is_initialized
 
+
+  !>cFMS_set_compute_domain
+  module subroutine cFMS_set_compute_domain(domain_id, xbegin, xend, ybegin, yend, xsize, ysize, &
+       x_is_global, y_is_global, tile_count) bind(C, name="cFMS_set_compute_domain")
+    
+    implicit none
+    integer, intent(in),  optional :: domain_id
+    integer, intent(in),  optional :: xbegin, xend, ybegin, yend, xsize, ysize
+    logical, intent(in),  optional :: x_is_global, y_is_global
+    integer, intent(in),  optional :: tile_count
+
+    integer :: xbegin_f, xend_f, ybegin_f, yend_f, xsize_f, ysize_f, tile_count_f
+
+    xbegin_f = xbegin + 1
+    ybegin_f = ybegin + 1
+    xend_f = xend + 1
+    yend_f = yend + 1
+    tile_count_f = tile_count + 1
+    
+    call cFMS_set_current_domain(domain_id)
+    call fms_mpp_domains_set_compute_domain(current_domain, xbegin_f, xend_f, ybegin_f, yend_f, xsize, ysize, &
+                                            x_is_global, y_is_global, tile_count_f)
+    
+  end subroutine cFMS_set_compute_domain
+
+  
   
   !> cFMS_set_current_domain sets the domain to the current_domain where the
   !! current_domain has id=domain_id
@@ -177,6 +203,55 @@ contains
     end if
     
   end subroutine cFMS_set_current_nest_domain
-  
+
+
+  !> cFMS_set_data_domain
+  module subroutine cFMS_set_data_domain(domain_id, xbegin, xend, ybegin, yend, xsize, ysize, &
+       x_is_global, y_is_global, tile_count) bind(C, name="cFMS_set_data_domain")
+    
+    implicit none
+    integer, intent(in),  optional :: domain_id
+    integer, intent(in),  optional :: xbegin, xend, ybegin, yend, xsize, ysize
+    logical, intent(in),  optional :: x_is_global, y_is_global
+    integer, intent(in),  optional :: tile_count
+
+    integer :: xbegin_f, xend_f, ybegin_f, yend_f, tile_count_f
+
+    xbegin_f = xbegin + 1
+    ybegin_f = ybegin + 1
+    xend_f = xend + 1
+    yend_f = yend + 1
+    tile_count_f = tile_count + 1
+    
+    call cFMS_set_current_domain(domain_id)
+    call fms_mpp_domains_set_data_domain(current_domain, xbegin_f, xend_f, ybegin_f, yend_f, xsize, ysize, &
+                                         x_is_global, y_is_global, tile_count_f)
+
+  end subroutine cFMS_set_data_domain
+
+
+  !> cFMS_set_global_domain
+  module subroutine cFMS_set_global_domain(domain_id, xbegin, xend, ybegin, yend, xsize, ysize, tile_count) &
+       bind(C, name="cFMS_set_global_domain")
+    implicit none
+    integer, intent(in),  optional :: domain_id
+    integer, intent(in),  optional :: xbegin, xend, ybegin, yend, xsize, ysize
+    integer, intent(in),  optional :: tile_count
+
+    integer :: xbegin_f, xend_f, ybegin_f, yend_f, xsize_f, ysize_f, tile_count_f
+
+    xbegin_f = xbegin + 1
+    ybegin_f = ybegin + 1
+    xend_f = xend + 1
+    yend_f = yend + 1
+    tile_count_f = tile_count + 1
+    
+    call cFMS_set_current_domain(domain_id)
+    call fms_mpp_domains_set_global_domain(current_domain, xbegin_f, xend_f, ybegin_f, yend_f, &
+                                           xsize, ysize, tile_count_f)
+    
+  end subroutine cFMS_set_global_domain
+
+
 
 end submodule cmpp_domains_smod

--- a/cfms/cmpp_domains.h
+++ b/cfms/cmpp_domains.h
@@ -60,10 +60,12 @@ extern void cFMS_get_domain_pelist(int pelist[], int *domain_id);
 extern void cFMS_get_layout(int layout[2], int *domain_id);
 
 extern void cFMS_set_compute_domain(int *domain_id, int *xbegin, int *xend, int *ybegin, int *yend,
-                                    int *xsize, int *ysize, bool *x_is_global, bool *y_is_global, int *tile_count);
+                                    int *xsize, int *ysize, bool *x_is_global, bool *y_is_global, int *tile_count,
+                                    int *whalo, int *shalo);
 
 extern void cFMS_set_data_domain(int *domain_id, int *xbegin, int *xend, int *ybegin, int *yend,
-                                 int *xsize, int *ysize, bool *x_is_global, bool *y_is_global, int *tile_count);
+                                 int *xsize, int *ysize, bool *x_is_global, bool *y_is_global, int *tile_count,
+                                 int *whalo, int *shalo);
 
 extern void cFMS_set_global_domain(int *domain_id, int *xbegin, int *xend, int *ybegin, int *yend,
                                    int *xsize, int *ysize, int *tile_count);

--- a/cfms/cmpp_domains.h
+++ b/cfms/cmpp_domains.h
@@ -1,4 +1,4 @@
-/************************************************************************
+11;rgb:fcfc/e8e8/e8e8/************************************************************************
 !*                   GNU Lesser General Public License
 !*
 !* This file is part of the GFDL Flexible Modeling System (FMS).
@@ -34,14 +34,23 @@ extern void cFMS_define_layout(int global_indices[4], int *ndivs, int layout[2])
 
 extern void cFMS_define_nest_domains(int *num_nest, int *ntiles, int nest_level[], int tile_fine[], int tile_course[],
                                      int istart_coarse[], int icount_coarse[], int jstart_coarse[], int jcount_coarse[],
-                                     int npes_nest_tile[], int x_refine[], int y_refine[], int *nest_domain_id, int* domain_id,
-                                     int *extra_halo, char *name);
+                                     int npes_nest_tile[], int x_refine[], int y_refine[], int *nest_domain_id,
+                                     int* domain_id, int *extra_halo, char *name);
 
 extern bool cFMS_domain_is_initialized(int *domain_id);
 
 extern void cFMS_define_domains_easy(cDomainStruct cdomain);
 
 extern void cFMS_define_nest_domains_easy(cNestDomainStruct cnestdomain);
+
+extern void cFMS_set_compute_domain(int *domain_id, int *xbegin, int *xend, int *ybegin, int *yend,
+                                    int *xsize, int *ysize, bool *x_is_global, bool *y_is_global, int *tile_count);
+
+extern void cFMS_set_data_domain(int *domain_id, int *xbegin, int *xend, int *ybegin, int *yend,
+                                 int *xsize, int *ysize, bool *x_is_global, bool *y_is_global, int *tile_count);
+
+extern void cFMS_set_global_domain(int *domain_id, int *xbegin, int *xend, int *ybegin, int *yend,
+                                   int *xsize, int *ysize, int *tile_count);
 
 void cFMS_define_domains_easy(cDomainStruct cdomain)
 {

--- a/cfms/cmpp_domains.h
+++ b/cfms/cmpp_domains.h
@@ -111,6 +111,55 @@ void cFMS_define_nest_domains_easy(cNestDomainStruct cnestdomain)
                            cnestdomain.name);
 }
 
+void cFMS_null_cdomain(cDomainStruct *cdomain)
+{
+  cdomain->global_indices = NULL;
+  cdomain->layout = NULL;
+  cdomain->domain_id = NULL;
+  cdomain->pelist = NULL;
+  cdomain->xflags = NULL;
+  cdomain->yflags = NULL;
+  cdomain->xhalo = NULL;
+  cdomain->yhalo = NULL;
+  cdomain->xextent = NULL;
+  cdomain->yextent = NULL;
+  cdomain->maskmap = NULL;
+  cdomain->name = NULL;
+  cdomain->symmetry = NULL;
+  cdomain->memory_size = NULL;
+  cdomain->whalo = NULL;
+  cdomain->ehalo = NULL;
+  cdomain->shalo = NULL;
+  cdomain->nhalo = NULL;
+  cdomain->is_mosaic = NULL;
+  cdomain->tile_count = NULL;
+  cdomain->tile_id = NULL;
+  cdomain->complete = NULL;
+  cdomain->x_cyclic_offset = NULL;
+  cdomain->y_cyclic_offset = NULL;
+}
+
+void cFMS_null_cnest_domain(cNestDomainStruct *cnest_domain)
+{
+  cnest_domain->num_nest = NULL;
+  cnest_domain->ntiles = NULL;
+  cnest_domain->nest_level = NULL;
+  cnest_domain->tile_fine = NULL;
+  cnest_domain->tile_coarse = NULL;
+  cnest_domain->istart_coarse = NULL;
+  cnest_domain->icount_coarse = NULL;
+  cnest_domain->jstart_coarse = NULL;
+  cnest_domain->jcount_coarse = NULL;
+  cnest_domain->npes_nest_tile = NULL;
+  cnest_domain->x_refine = NULL;
+  cnest_domain->y_refine = NULL;
+  cnest_domain->nest_domain_id = NULL;
+  cnest_domain->domain_id = NULL;
+  cnest_domain->extra_halo = NULL;
+  cnest_domain->name = NULL;
+}
+
+
 #endif
 
                    

--- a/cfms/cmpp_domains.h
+++ b/cfms/cmpp_domains.h
@@ -1,4 +1,4 @@
-11;rgb:fcfc/e8e8/e8e8/************************************************************************
+/************************************************************************
 !*                   GNU Lesser General Public License
 !*
 !* This file is part of the GFDL Flexible Modeling System (FMS).
@@ -42,6 +42,22 @@ extern bool cFMS_domain_is_initialized(int *domain_id);
 extern void cFMS_define_domains_easy(cDomainStruct cdomain);
 
 extern void cFMS_define_nest_domains_easy(cNestDomainStruct cnestdomain);
+
+extern void cFMS_get_compute_domain(int *domain_id, int *xbegin, int *xend, int *ybegin, int *yend,
+                                    int *xsize, int *xmax_size, int *ysize, int *ymax_size,
+                                    bool *x_is_global, bool *y_is_global, int *tile_count, int *position,
+                                    int *whalo, int *shalo);
+  
+extern void cFMS_get_data_domain(int *domain_id, int *xbegin, int *xend, int *ybegin, int *yend,
+                                 int *xsize, int *xmax_size, int *ysize, int *ymax_size,
+                                 bool *x_is_global, bool *y_is_global, int *tile_count, int *position,
+                                 int *whalo, int *shalo);
+
+extern void cFMS_get_domain_name(char *domain_name_c, int *domain_id);
+
+extern void cFMS_get_domain_pelist(int pelist[], int *domain_id);
+
+extern void cFMS_get_layout(int layout[2], int *domain_id);
 
 extern void cFMS_set_compute_domain(int *domain_id, int *xbegin, int *xend, int *ybegin, int *yend,
                                     int *xsize, int *ysize, bool *x_is_global, bool *y_is_global, int *tile_count);

--- a/test_cfms/cfms/Makefile.am
+++ b/test_cfms/cfms/Makefile.am
@@ -24,19 +24,24 @@ AM_CPPFLAGS = -I. -I$(MODDIR) -I${top_builddir}/cfms
 # Link to the FMS library.
 LDADD = ${top_builddir}/libcFMS/libcFMS.la
 
-check_PROGRAMS = test_define_domains test_get_domains
+check_PROGRAMS = test_define_domains \
+	test_get_domains \
+	test_set_domains
 
-TESTS = test_define_domains.sh test_get_domains.sh
+TESTS = test_define_domains.sh \
+	test_get_domains.sh \
+	test_set_domains.sh
 
 test_define_domains_SOURCES = test_define_domains.c
 test_get_domains_SOURCES = test_get_domains.c
+test_set_domains_SOURCES = test_set_domains.c
 
 TEST_EXTENSIONS = .sh
 SH_LOG_DRIVER = env AM_TAP_AWK='$(AWK)' $(SHELL) \
                   $(abs_top_srcdir)/test_cfms/tap-driver.sh
 
 # Include these files with the distribution.
-EXTRA_DIST = test_define_domains.sh test_get_domains.sh
+EXTRA_DIST = test_define_domains.sh test_get_domains.sh test_set_domains.sh
 
 # Clean up
 CLEANFILES = input.nml *.nc* *.out *.dpi *.spi *.dyn *.spl *_table* input*

--- a/test_cfms/cfms/Makefile.am
+++ b/test_cfms/cfms/Makefile.am
@@ -25,24 +25,21 @@ AM_CPPFLAGS = -I. -I$(MODDIR) -I${top_builddir}/cfms
 LDADD = ${top_builddir}/libcFMS/libcFMS.la
 
 check_PROGRAMS = test_define_domains \
-	test_get_domains \
-	test_set_domains
+	test_getset_domains
 
 TESTS = test_define_domains.sh \
-	test_get_domains.sh \
-	test_set_domains.sh
+	test_getset_domains.sh
 
 test_define_domains_SOURCES = test_define_domains.c
-test_get_domains_SOURCES = test_get_domains.c
-test_set_domains_SOURCES = test_set_domains.c
+test_getset_domains_SOURCES = test_getset_domains.c
 
 TEST_EXTENSIONS = .sh
 SH_LOG_DRIVER = env AM_TAP_AWK='$(AWK)' $(SHELL) \
                   $(abs_top_srcdir)/test_cfms/tap-driver.sh
 
 # Include these files with the distribution.
-EXTRA_DIST = test_define_domains.sh test_get_domains.sh test_set_domains.sh
+EXTRA_DIST = test_define_domains.sh test_getset_domains.sh
 
 # Clean up
-CLEANFILES = input.nml *.nc* *.out *.dpi *.spi *.dyn *.spl *_table* input*
+CLEANFILES = input.nml *.nc* *.out *.dpi *.spi *.dyn *.spl *_table* input* *trs
 

--- a/test_cfms/cfms/Makefile.am
+++ b/test_cfms/cfms/Makefile.am
@@ -24,18 +24,19 @@ AM_CPPFLAGS = -I. -I$(MODDIR) -I${top_builddir}/cfms
 # Link to the FMS library.
 LDADD = ${top_builddir}/libcFMS/libcFMS.la
 
-check_PROGRAMS = test_define_domains
+check_PROGRAMS = test_define_domains test_get_domains
 
-TESTS = test_define_domains.sh 
+TESTS = test_define_domains.sh test_get_domains.sh
 
 test_define_domains_SOURCES = test_define_domains.c
+test_get_domains_SOURCES = test_get_domains.c
 
 TEST_EXTENSIONS = .sh
 SH_LOG_DRIVER = env AM_TAP_AWK='$(AWK)' $(SHELL) \
                   $(abs_top_srcdir)/test_cfms/tap-driver.sh
 
 # Include these files with the distribution.
-EXTRA_DIST = test_define_domains.sh 
+EXTRA_DIST = test_define_domains.sh test_get_domains.sh
 
 # Clean up
 CLEANFILES = input.nml *.nc* *.out *.dpi *.spi *.dyn *.spl *_table* input*

--- a/test_cfms/cfms/test_cfms.h
+++ b/test_cfms/cfms/test_cfms.h
@@ -5,6 +5,8 @@
 
 #define TRUE 1
 #define FALSE 0
+#define SUCCESS 0
+#define FAIL 1
 
 int any(int n, int* array, int value)
 {
@@ -19,7 +21,7 @@ int errmsg_int(int answer, int test, char *message)
   printf("\nEXPECTED %d BUT GOT %d FOR %s\n", answer, test, message);
   printf("HEREHERE %d\n", FATAL);
   cFMS_error(FATAL, "GOODBYE!");
-  exit(1);
+  exit(FAIL);
 }
 
 #endif

--- a/test_cfms/cfms/test_cfms.h
+++ b/test_cfms/cfms/test_cfms.h
@@ -1,6 +1,8 @@
 #ifndef TEST_CFMS_H_
 #define TEST_CMFS_H_
 
+#include <cfms.h>
+
 #define TRUE 1
 #define FALSE 0
 
@@ -12,5 +14,12 @@ int any(int n, int* array, int value)
   return FALSE;
 }
                             
+int errmsg_int(int answer, int test, char *message)
+{
+  printf("\nEXPECTED %d BUT GOT %d FOR %s\n", answer, test, message);
+  printf("HEREHERE %d\n", FATAL);
+  cFMS_error(FATAL, "GOODBYE!");
+  exit(1);
+}
 
 #endif

--- a/test_cfms/cfms/test_define_domains.c
+++ b/test_cfms/cfms/test_define_domains.c
@@ -23,9 +23,6 @@
 #include <cfms.h>
 #include <test_cfms.h>
 
-#define SUCCESS 0
-#define FAIL 1
-
 #define NX 96
 #define NY 96
 #define NX_FINE 48
@@ -37,16 +34,16 @@
 #define COARSE_NPES 4
 #define FINE_NPES 4
 
-int test_cFMS_define_domains(int *global_pelist);
-
 int main() {
   
   int *global_pelist = NULL;
 
-  int ndomain=2, domain_id=1;
-  int nnest_domain=2, nest_domain_id=1;
-  cDomainStruct cdomain = cDomainStruct_init;
-  cNestDomainStruct cnest_domain = cNestDomain_init;  
+  int ndomain=2;
+  int nnest_domain=2;
+  int domain_id=1;
+  int nest_domain_id=1;
+  cDomainStruct cdomain;
+  cNestDomainStruct cnest_domain;  
   
   int coarse_global_indices[4] = {0, NX-1, 0, NY-1};
   int coarse_npes=COARSE_NPES, coarse_pelist[COARSE_NPES];
@@ -55,6 +52,13 @@ int main() {
   int coarse_ehalo=2;
   int coarse_shalo=2;
   int coarse_nhalo=2;
+  int coarse_xflags = WEST;
+  int coarse_yflags = SOUTH;
+  bool is_mosaic = false;
+  bool symmetry = false;
+  
+  int coarse_xextent[4] = {NX/2,NX/2,NX/2,NX/2};
+  int coarse_yextent[4] = {NY/2,NY/2,NY/2,NY/2};
 
   int fine_global_indices[4] = {0, NX_FINE-1, 0, NY_FINE-1};
   int fine_npes=FINE_NPES, fine_pelist[FINE_NPES];
@@ -65,6 +69,8 @@ int main() {
   int fine_nhalo=2;
   
   cFMS_init(NULL, NULL, &ndomain, &nnest_domain);
+  cFMS_null_cdomain(&cdomain);
+  cFMS_null_cnest_domain(&cnest_domain);
 
   //get global pelist
   {
@@ -73,45 +79,72 @@ int main() {
   cFMS_set_pelist_npes(&npes);
   cFMS_get_current_pelist(global_pelist, NULL, NULL);
   }
-  
+
   //set coarse domain as tile=0
   {
-    for(int i=0 ; i<coarse_npes; i++) {
-      coarse_pelist[i] = global_pelist[i];
-    }
-    char name_coarse[80] = "test coarse pelist";
+    for(int i=0 ; i<coarse_npes; i++) coarse_pelist[i] = global_pelist[i];
+    char name_coarse[NAME_LENGTH] = "test coarse pelist";
     cFMS_set_pelist_npes(&coarse_npes);
     cFMS_declare_pelist(coarse_pelist, name_coarse, NULL);    
-    
+
     if(any(coarse_npes, coarse_pelist, cFMS_pe())) {
-      char name[80] = "test coarse domain"; cdomain.name  = name;      
+
+      cFMS_set_pelist_npes(&coarse_npes);
+      cFMS_set_current_pelist(coarse_pelist, NULL);
+      
+      char name[NAME_LENGTH] = "test coarse domain"; 
+
+      bool *maskmap_blob = (bool *)calloc(4,sizeof(bool));
+      cdomain.maskmap = (bool **)calloc(2,sizeof(bool *));
+      for(int i=0; i<2; i++) cdomain.maskmap[i] = maskmap_blob+2*i;
+      for(int i=0; i<2 ; i++) for (int j=0; j<2; j++) cdomain.maskmap[i][j] = true;
+      
+      int xextent[2] = {0,0};
+      int yextent[2] = {0,0};
+      bool is_mosaic = false;
+      
+      cdomain.domain_id = &domain_id; //test to make sure domain is set correctly in cFMS;
+      cdomain.name   = name;
+      cdomain.pelist = coarse_pelist;
       cdomain.global_indices = coarse_global_indices;      
       cdomain.whalo = &coarse_whalo;
       cdomain.ehalo = &coarse_ehalo;
       cdomain.shalo = &coarse_shalo;
       cdomain.nhalo = &coarse_nhalo;
       cdomain.tile_id = &coarse_tile_id;
-      cdomain.domain_id = &domain_id; //test to make sure domain is set correctly in cFMS;
+      cdomain.xextent = coarse_xextent;
+      cdomain.yextent = coarse_yextent;
+      cdomain.xflags = &coarse_xflags;
+      cdomain.yflags = &coarse_yflags;
+      cdomain.xextent = xextent;
+      cdomain.yextent = yextent;
+      cdomain.is_mosaic = &is_mosaic;
       cdomain.layout = (int *)malloc(2*sizeof(int));
       int ndivs = coarse_npes; cFMS_define_layout(coarse_global_indices, &ndivs, cdomain.layout);      
 
-      cFMS_set_current_pelist(coarse_pelist, NULL);
       cFMS_define_domains_easy(cdomain);
+
+      free(maskmap_blob);
+      free(cdomain.layout);
+      cFMS_null_cdomain(&cdomain);
     }
   }
   
   cFMS_set_current_pelist(NULL, NULL);
-  
-  {//set fine domain as tile=1
-    char name_fine[80] = "test fine pelist";
-    for(int i=0; i<fine_npes; i++) {
-      fine_pelist[i] = global_pelist[COARSE_NPES+i];
-    }
+
+  //set fine domain as tile=1
+  {
+    char name_fine[NAME_LENGTH] = "test fine pelist";
+    for(int i=0; i<fine_npes; i++) fine_pelist[i] = global_pelist[COARSE_NPES+i];
     cFMS_set_pelist_npes(&fine_npes);
     cFMS_declare_pelist(fine_pelist, name_fine, NULL);
-
+    
     if(any(FINE_NPES, fine_pelist, cFMS_pe())) {
-      char name[80] = "test fine domain" ; cdomain.name = name;
+      
+      cFMS_set_pelist_npes(&fine_npes);
+      cFMS_set_current_pelist(fine_pelist, NULL);
+      
+      char name[NAME_LENGTH] = "test fine domain" ; cdomain.name = name;
       cdomain.global_indices = fine_global_indices;
       cdomain.tile_id = &fine_tile_id;
       cdomain.whalo = &fine_whalo;
@@ -122,16 +155,19 @@ int main() {
       cdomain.layout = (int *)malloc(2*sizeof(int));
       int ndivs = FINE_NPES; cFMS_define_layout(fine_global_indices, &ndivs, cdomain.layout);
 
-      cFMS_set_current_pelist(fine_pelist, NULL);
       cFMS_define_domains_easy(cdomain);
+      
+      free(cdomain.layout);
+      cFMS_null_cdomain(&cdomain);
     }
   }
   
   cFMS_set_current_pelist(NULL, NULL);
 
   if( !cFMS_domain_is_initialized(&domain_id) ) cFMS_error(FATAL, "domain is not initialized");
-  
-  { //set nest domain
+
+  //set nest domain
+  { 
     char name[80] = "test nest domain"; cnest_domain.name = name;
     int num_nest=1; cnest_domain.num_nest = &num_nest;
     int ntiles=2;   cnest_domain.ntiles=&ntiles;
@@ -149,6 +185,7 @@ int main() {
     cnest_domain.domain_id = &domain_id;
     
     cFMS_define_nest_domains_easy(cnest_domain);
+    cFMS_null_cnest_domain(&cnest_domain);
   }
 
   cFMS_set_current_pelist(NULL, NULL);


### PR DESCRIPTION
In this PR,

1.  Warnings and errors associated with C-Fortran interoperability for boolean quantities have been fixed.
2.  The starting index discrepancies for gridpoints between C and Fortran have been explicitly taken into account where cFMS expects the absolute starting index to be 0 in the external program. cFMS will shift all relevant values by +1 to match Fortran absolute starting index convention that starts from 1 before calling the FMS subroutine/function.  For example, cFMS expects the external program to send in global_indices = [0,95,0,95] and will convert the indices to [1,96,1,96] for mpp_define_domains.
4.  The following wrappers were added:
    * mpp_get_compute_domain
    * mpp_get_data_domain
    * mpp_set_compute_domain
    * mpp_get_compute_domain
    * mpp_get_global_domain