### PR TITLE
Character length fixes, minor parameters cleanup

### DIFF
--- a/cfms/cfms.F90
+++ b/cfms/cfms.F90
@@ -45,6 +45,8 @@ module cFMS_mod
 
   implicit none
 
+  private
+
   public :: cFMS_init
   public :: cFMS_end, cFMS_error, cFMS_set_pelist_npes
   public :: cFMS_declare_pelist, cFMS_get_current_pelist, cFMS_npes, cFMS_pe, cFMS_set_current_pelist
@@ -61,39 +63,43 @@ module cFMS_mod
   public :: cFMS_set_data_domain
   public :: cFMS_set_global_domain
   
-  integer, parameter :: NAME_LENGTH = 64 !< value taken from mpp_domains
-  integer, parameter :: MESSAGE_LENGTH=128
-  character(NAME_LENGTH), parameter :: input_nml_path="./input.nml"
+  integer, public, parameter :: NAME_LENGTH    = 64 !< value taken from mpp_domains
+  integer, public, parameter :: MESSAGE_LENGTH = 128
+  integer, public, parameter :: PATH_LENGTH    = 128
+  character(PATH_LENGTH-1), parameter :: input_nml_path="./input.nml"
 
+  integer, public, bind(C, name="NAME_LENGTH")    :: NAME_LENGTH_C    = NAME_LENGTH
+  integer, public, bind(C, name="MESSAGE_LENGTH") :: MESSAGE_LENGTH_C = MESSAGE_LENGTH
+  integer, public, bind(C, name="PATH_LENGTH")    :: PATH_LENGTH_C    = PATH_LENGTH
+  
   integer, public, bind(C, name="cFMS_pelist_npes") :: npes
   integer, public, bind(C, name="NOTE")    :: NOTE_C    = NOTE
   integer, public, bind(C, name="WARNING") :: WARNING_C = WARNING
   integer, public, bind(C, name="FATAL")   :: FATAL_C   = FATAL
 
   integer, public, bind(C, name="GLOBAL_DATA_DOMAIN") :: GLOBAL_DATA_DOMAIN_C = GLOBAL_DATA_DOMAIN
-  integer, public, bind(C, name="BGRID_NE") :: BGRID_NE_C = BGRID_NE
-  integer, public, bind(C, name="CGRID_NE") :: CGRID_NE_C = CGRID_NE
-  integer, public, bind(C, name="DGRID_NE") :: DGRID_NE_C = DGRID_NE
-  integer, public, bind(C, name="AGRID") :: AGRID_C = AGRID
+  integer, public, bind(C, name="BGRID_NE") ::           BGRID_NE_C = BGRID_NE
+  integer, public, bind(C, name="CGRID_NE") ::           CGRID_NE_C = CGRID_NE
+  integer, public, bind(C, name="DGRID_NE") ::           DGRID_NE_C = DGRID_NE
+  integer, public, bind(C, name="AGRID")    ::           AGRID_C = AGRID
   integer, public, bind(C, name="FOLD_SOUTH_EDGE") :: FOLD_SOUTH_EDGE_C = FOLD_SOUTH_EDGE
-  integer, public, bind(C, name="FOLD_WEST_EDGE")  :: FOLD_WEST_EDGE_C = FOLD_WEST_EDGE
-  integer, public, bind(C, name="FOLD_EAST_EDGE")  :: FOLD_EAST_EDGE_C = FOLD_EAST_EDGE
+  integer, public, bind(C, name="FOLD_WEST_EDGE")  :: FOLD_WEST_EDGE_C  = FOLD_WEST_EDGE
+  integer, public, bind(C, name="FOLD_EAST_EDGE")  :: FOLD_EAST_EDGE_C  = FOLD_EAST_EDGE
   integer, public, bind(C, name="CYCLIC_GLOBAL_DOMAIN") :: CYCLIC_GLOBAL_DOMAIN_C = CYCLIC_GLOBAL_DOMAIN
   integer, public, bind(C, name="NUPDATE") :: NUPDATE_C = NUPDATE
   integer, public, bind(C, name="EUPDATE") :: EUPDATE_C = EUPDATE
   integer, public, bind(C, name="XUPDATE") :: XUPDATE_C = XUPDATE
   integer, public, bind(C, name="YUPDATE") :: YUPDATE_C = YUPDATE
-  integer, public, bind(C, name="NORTH") :: NORTH_C = NORTH
-  integer, public, bind(C, name="NORTH_EAST") :: NORTH_EAST_C = NORTH_EAST
-  integer, public, bind(C, name="EAST")  :: EAST_C = EAST
-  integer, public, bind(C, name="SOUTH_EAST") :: SOUTH_EAST_C = SOUTH_EAST
-  integer, public, bind(C, name="CORNER") :: CORNER_C = CORNER
-  integer, public, bind(C, name="CENTER") :: CENTER_C = CENTER
-  integer, public, bind(C, name="SOUTH") :: SOUTH_C = SOUTH
-  integer, public, bind(C, name="SOUTH_WEST") :: SOUTH_WEST_C = SOUTH_WEST  
-  integer, public, bind(C, name="WEST")  :: WEST_C = WEST
-  integer, public, bind(C, name="NORTH_WEST") :: NORTH_WEST_C = NORTH_WEST
-
+  integer, public, bind(C, name="NORTH")   :: NORTH_C = NORTH
+  integer, public, bind(C, name="NORTH_EAST") :: NORTH_EAST_C  = NORTH_EAST
+  integer, public, bind(C, name="EAST")       :: EAST_C        = EAST
+  integer, public, bind(C, name="SOUTH_EAST") :: SOUTH_EAST_C  = SOUTH_EAST
+  integer, public, bind(C, name="CORNER")     :: CORNER_C      = CORNER
+  integer, public, bind(C, name="CENTER")     :: CENTER_C      = CENTER
+  integer, public, bind(C, name="SOUTH")      :: SOUTH_C       = SOUTH
+  integer, public, bind(C, name="SOUTH_WEST") :: SOUTH_WEST_C  = SOUTH_WEST  
+  integer, public, bind(C, name="WEST")       :: WEST_C        = WEST
+  integer, public, bind(C, name="NORTH_WEST") :: NORTH_WEST_C  = NORTH_WEST
 
   type(FmsMppDomain2D), allocatable, target,  public :: domain(:)
   type(FmsMppDomain2D), pointer  :: current_domain  
@@ -101,6 +107,10 @@ module cFMS_mod
   type(FmsMppDomainsNestDomain_type), allocatable, target, public :: nest_domain(:)
   type(FmsMppDomainsNestDomain_type), pointer :: current_nest_domain
 
+  !TODO
+  !domain1d
+  !domainUG
+  
   interface
 
      module subroutine cFMS_declare_pelist(pelist, name, commID) bind(C, name="cFMS_declare_pelist")
@@ -306,9 +316,9 @@ contains
     integer, intent(in), optional :: localcomm
     integer, intent(in), optional :: ndomain
     integer, intent(in), optional :: nnest_domain
-    character(c_char), intent(in), optional :: alt_input_nml_path(NAME_LENGTH)
+    character(c_char), intent(in), optional :: alt_input_nml_path(PATH_LENGTH)
     
-    character(100) :: alt_input_nml_path_f = input_nml_path
+    character(PATH_LENGTH-1) :: alt_input_nml_path_f = input_nml_path
     
     if(present(alt_input_nml_path)) &
          alt_input_nml_path_f = fms_string_utils_c2f_string(alt_input_nml_path)

--- a/cfms/cfms.h
+++ b/cfms/cfms.h
@@ -23,38 +23,45 @@
 #include <cmpp.h>
 #include <cmpp_domains.h>
 
-#define NAME_LENGTH 64 
+#define NAME_LENGTH 64
 #define MESSAGE_LENGTH 128
+#define PATH_LENGTH 128
 
 extern const int NOTE;
 extern const int WARNING;
 extern const int FATAL;
 
-extern int GLOBAL_DATA_DOMAIN;
-extern int BGRID_NE;
-extern int CGRID_NE;
-extern int DGRID_NE;
-extern int AGRID;
-extern int FOLD_SOUTH_EDGE;
-extern int FOLD_NORTH_EDGE;
-extern int FOLD_WEST_EDGE;
-extern int FOLD_EAST_EDGE;  
-extern int CYCLIC_GLOBAL_DOMAIN;
-extern int NUPDATE;
-extern int EUPDATE;
-extern int XUPDATE;
-extern int YUPDATE;
-extern int NORTH;
-extern int NORTH_EAST;
-extern int EAST;
-extern int SOUTH_EAST;
-extern int CORNER;
-extern int CENTER;
-extern int SOUTH;
-extern int SOUTH_WEST;
-extern int WEST;
-extern int NORTH_WEST;
-extern int CYCLIC_GLOBAL_DOMAIN;
+/*
+extern const int NAME_LENGTH;
+extern const int MESSAGE_LENGTH;
+extern const int PATH_LENGTH;
+*/
+
+extern const int GLOBAL_DATA_DOMAIN;
+extern const int BGRID_NE;
+extern const int CGRID_NE;
+extern const int DGRID_NE;
+extern const int AGRID;
+extern const int FOLD_SOUTH_EDGE;
+extern const int FOLD_NORTH_EDGE;
+extern const int FOLD_WEST_EDGE;
+extern const int FOLD_EAST_EDGE;  
+extern const int CYCLIC_GLOBAL_DOMAIN;
+extern const int NUPDATE;
+extern const int EUPDATE;
+extern const int XUPDATE;
+extern const int YUPDATE;
+extern const int NORTH;
+extern const int NORTH_EAST;
+extern const int EAST;
+extern const int SOUTH_EAST;
+extern const int CORNER;
+extern const int CENTER;
+extern const int SOUTH;
+extern const int SOUTH_WEST;
+extern const int WEST;
+extern const int NORTH_WEST;
+extern const int CYCLIC_GLOBAL_DOMAIN;
 
 extern void cFMS_init(int *localcomm, char *alt_input_nml_path, int *ndomain, int *nnest_domain);
 

--- a/cfms/cmpp.F90
+++ b/cfms/cmpp.F90
@@ -31,7 +31,7 @@ contains
     character(c_char), intent(in), optional :: name(NAME_LENGTH)
     integer, intent(out), optional :: commID
 
-    character(len=NAME_LENGTH) :: name_f=" " !mpp default
+    character(len=NAME_LENGTH-1) :: name_f=" " !mpp default
 
     if(present(name)) name_f = fms_string_utils_c2f_string(name)
     call fms_mpp_declare_pelist(pelist, name_f, commID)
@@ -44,7 +44,7 @@ contains
     implicit none
     integer, intent(in), value :: errortype
     character(c_char), intent(in), optional :: errormsg(MESSAGE_LENGTH)
-    character(len=MESSAGE_LENGTH) :: errormsg_f=""
+    character(len=MESSAGE_LENGTH-1) :: errormsg_f=""
 
     if(present(errormsg)) errormsg_f = fms_string_utils_c2f_string(errormsg)
     call fms_mpp_error(errortype, trim(errormsg_f))
@@ -60,7 +60,7 @@ contains
     character(c_char), intent(out), optional :: name(NAME_LENGTH)
     integer, intent(out), optional :: commID
 
-    character(len=NAME_LENGTH) :: name_f=" " !mpp default
+    character(len=NAME_LENGTH-1) :: name_f=" " !mpp default
     
     if(present(name)) name_f = fms_string_utils_c2f_string(name)
     call fms_mpp_get_current_pelist(pelist, name_f, commID)

--- a/cfms/cmpp_domains.F90
+++ b/cfms/cmpp_domains.F90
@@ -49,7 +49,7 @@ contains
     integer, intent(in), optional :: x_cyclic_offset
     integer, intent(in), optional :: y_cyclic_offset
     
-    character(len=NAME_LENGTH) :: name_f = "cdomain"
+    character(len=NAME_LENGTH-1) :: name_f = "cdomain"
     integer :: global_indices_f(4)
     logical(c_bool), pointer :: maskmap_f(:,:) => NULL()
     logical :: symmetry_f  = .False.
@@ -145,7 +145,7 @@ contains
 
     integer :: istart_coarse_f(num_nest), jstart_coarse_f(num_nest)
     integer :: tile_fine_f(num_nest), tile_coarse_f(num_nest)
-    character(100) :: name_f = "cnest_domain"    
+    character(NAME_LENGTH-1) :: name_f = "cnest_domain"    
 
     istart_coarse_f = istart_coarse + 1
     jstart_coarse_f = jstart_coarse + 1
@@ -253,7 +253,7 @@ contains
     implicit none
     character(c_char), intent(out) :: domain_name_c(NAME_LENGTH)
     integer, intent(in),  optional :: domain_id
-    character(len=NAME_LENGTH) :: domain_name_f
+    character(len=NAME_LENGTH-1) :: domain_name_f
     
     call cFMS_set_current_domain(domain_id)
     domain_name_f = fms_mpp_domains_get_domain_name(current_domain)


### PR DESCRIPTION
In this PR, the length of Fortran strings have been revised to take into account C null character length difference.
In addition, parameters in cFMS.F90 have been cleaned-up.