### PR TITLE
Changes to use single pointer for maskmap in define_domains

### DIFF
--- a/c_fms/c_fms.h
+++ b/c_fms/c_fms.h
@@ -61,7 +61,7 @@ extern void cFMS_set_current_pelist(int *pelist, bool *no_sync);
 
 extern void cFMS_define_domains(int global_indices[4], int layout[2], int *domain_id, int pelist[], 
                                 int *xflags, int *yflags, int *xhalo, int *yhalo, int xextent[], int yextent[],
-                                bool **maskmap, char *name, bool *symmetry, int memory_size[2],
+                                bool *maskmap, char *name, bool *symmetry, int memory_size[2],
                                 int *whalo, int *ehalo, int *shalo, int *nhalo, bool *is_mosaic,
                                 int *tile_count, int *tile_id, bool *complete, int *x_cyclic_offset, int *y_cyclic_offset);
 
@@ -105,7 +105,7 @@ extern void cFMS_set_data_domain(int *domain_id, int *xbegin, int *xend, int *yb
 extern void cFMS_set_global_domain(int *domain_id, int *xbegin, int *xend, int *ybegin, int *yend,
                                    int *xsize, int *ysize, int *tile_count);
 
-extern void cFMS_update_domains_float_2d(int *field_shape, float **field, int *domain_id, int *flags, int *complete,
+extern void cFMS_update_domains_float_2d(int *field_shape, float *field, int *domain_id, int *flags, int *complete,
                                          int *position, int *whalo, int *ehalo, int *shalo, int *nhalo,
                                          char *name, int *tile_count);
 

--- a/test_cfms/c_fms/c_mpp_domains_helper.h
+++ b/test_cfms/c_fms/c_mpp_domains_helper.h
@@ -20,7 +20,7 @@ typedef struct {
   int* yhalo;
   int* xextent;
   int* yextent;
-  bool** maskmap;
+  bool* maskmap;
   char* name;
   bool* symmetry;
   int *memory_size; //memory_size[2]

--- a/test_cfms/c_fms/test_define_domains.c
+++ b/test_cfms/c_fms/test_define_domains.c
@@ -94,10 +94,12 @@ int main() {
       
       char name[NAME_LENGTH] = "test coarse domain"; 
 
-      bool *maskmap_blob = (bool *)calloc(4,sizeof(bool));
-      cdomain.maskmap = (bool **)calloc(2,sizeof(bool *));
-      for(int i=0; i<2; i++) cdomain.maskmap[i] = maskmap_blob+2*i;
-      for(int i=0; i<2 ; i++) for (int j=0; j<2; j++) cdomain.maskmap[i][j] = true;
+      // bool *maskmap_blob = (bool *)calloc(4,sizeof(bool));
+      // cdomain.maskmap = (bool **)calloc(2,sizeof(bool *));
+      // for(int i=0; i<2; i++) cdomain.maskmap[i] = maskmap_blob+2*i;
+      // for(int i=0; i<2 ; i++) for (int j=0; j<2; j++) cdomain.maskmap[i][j] = true;
+      cdomain.maskmap = (bool *)calloc(8,sizeof(bool));
+      for(int i=0; i<8; i++) cdomain.maskmap[i] = true;
       
       int xextent[2] = {0,0};
       int yextent[2] = {0,0};
@@ -124,7 +126,7 @@ int main() {
 
       cFMS_define_domains_easy(cdomain);
 
-      free(maskmap_blob);
+      free(cdomain.maskmap);
       free(cdomain.layout);
       cFMS_null_cdomain(&cdomain);
     }

--- a/test_cfms/c_fms/test_define_domains.c
+++ b/test_cfms/c_fms/test_define_domains.c
@@ -94,10 +94,6 @@ int main() {
       
       char name[NAME_LENGTH] = "test coarse domain"; 
 
-      // bool *maskmap_blob = (bool *)calloc(4,sizeof(bool));
-      // cdomain.maskmap = (bool **)calloc(2,sizeof(bool *));
-      // for(int i=0; i<2; i++) cdomain.maskmap[i] = maskmap_blob+2*i;
-      // for(int i=0; i<2 ; i++) for (int j=0; j<2; j++) cdomain.maskmap[i][j] = true;
       cdomain.maskmap = (bool *)calloc(8,sizeof(bool));
       for(int i=0; i<8; i++) cdomain.maskmap[i] = true;
       


### PR DESCRIPTION
**Description**
This PR enables a single pointer to be passed for `maskmap` as is done in the `pointer_to_array` method. This PR correlates to incoming changes from PR 10 in `pyFMS` which fixes the use of `maskmap` to also be a single pointer. Edit subsequent PRs could extend `pointer_to_array` to use logical as a data type as well.